### PR TITLE
Add stateful precompiled contract

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -43,8 +43,8 @@ import (
 // requires a deterministic gas count based on the input size of the Run method of the
 // contract.
 type PrecompiledContract interface {
-	RequiredGas(input []byte) uint64             // RequiredPrice calculates the contract gas use
-	Run(input []byte, _ StateDB) ([]byte, error) // Run runs the precompiled contract
+	RequiredGas(input []byte) uint64                   // RequiredPrice calculates the contract gas use
+	Run(input []byte, stateDB StateDB) ([]byte, error) // Run runs the precompiled contract
 }
 
 // PrecompiledContracts contains the precompiled contracts supported at the given fork.
@@ -98,6 +98,7 @@ var PrecompiledContractsBerlin = PrecompiledContracts{
 	common.BytesToAddress([]byte{0x7}): &bn256ScalarMulIstanbul{},
 	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{0x9}): &blake2F{},
+	common.BytesToAddress([]byte{0xa}): &statefulPrecompile{},
 }
 
 // PrecompiledContractsCancun contains the default set of pre-compiled Ethereum
@@ -113,6 +114,7 @@ var PrecompiledContractsCancun = PrecompiledContracts{
 	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{0x9}): &blake2F{},
 	common.BytesToAddress([]byte{0xa}): &kzgPointEvaluation{},
+	common.BytesToAddress([]byte{0xb}): &statefulPrecompile{},
 }
 
 // PrecompiledContractsPrague contains the set of pre-compiled Ethereum

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1284,6 +1284,9 @@ func (c *statefulPrecompile) Run(input []byte, stateDB StateDB) ([]byte, error) 
 	newCounter := new(big.Int).Add(new(big.Int).SetBytes(counter.Bytes()), big.NewInt(1))
 	stateDB.SetState(address, counterKey, common.BigToHash(newCounter))
 
+	resultArray := make([]byte, 32)
+	newCounter.FillBytes(resultArray)
+
 	// Return the updated counter as output
-	return newCounter.Bytes(), nil
+	return resultArray, nil
 }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -43,8 +43,8 @@ import (
 // requires a deterministic gas count based on the input size of the Run method of the
 // contract.
 type PrecompiledContract interface {
-	RequiredGas(input []byte) uint64  // RequiredPrice calculates the contract gas use
-	Run(input []byte) ([]byte, error) // Run runs the precompiled contract
+	RequiredGas(input []byte) uint64             // RequiredPrice calculates the contract gas use
+	Run(input []byte, _ StateDB) ([]byte, error) // Run runs the precompiled contract
 }
 
 // PrecompiledContracts contains the precompiled contracts supported at the given fork.
@@ -137,6 +137,7 @@ var PrecompiledContractsPrague = PrecompiledContracts{
 	common.BytesToAddress([]byte{0x11}): &bls12381Pairing{},
 	common.BytesToAddress([]byte{0x12}): &bls12381MapG1{},
 	common.BytesToAddress([]byte{0x13}): &bls12381MapG2{},
+	common.BytesToAddress([]byte{0x14}): &statefulPrecompile{},
 }
 
 var PrecompiledContractsBLS = PrecompiledContractsPrague
@@ -220,7 +221,7 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
+func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, stateDB StateDB, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
 	gasCost := p.RequiredGas(input)
 	if suppliedGas < gasCost {
 		return nil, 0, ErrOutOfGas
@@ -229,7 +230,7 @@ func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uin
 		logger.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
 	}
 	suppliedGas -= gasCost
-	output, err := p.Run(input)
+	output, err := p.Run(input, stateDB)
 	return output, suppliedGas, err
 }
 
@@ -240,7 +241,7 @@ func (c *ecrecover) RequiredGas(input []byte) uint64 {
 	return params.EcrecoverGas
 }
 
-func (c *ecrecover) Run(input []byte) ([]byte, error) {
+func (c *ecrecover) Run(input []byte, _ StateDB) ([]byte, error) {
 	const ecRecoverInputLength = 128
 
 	input = common.RightPadBytes(input, ecRecoverInputLength)
@@ -281,7 +282,7 @@ type sha256hash struct{}
 func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
-func (c *sha256hash) Run(input []byte) ([]byte, error) {
+func (c *sha256hash) Run(input []byte, _ StateDB) ([]byte, error) {
 	h := sha256.Sum256(input)
 	return h[:], nil
 }
@@ -296,7 +297,7 @@ type ripemd160hash struct{}
 func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
-func (c *ripemd160hash) Run(input []byte) ([]byte, error) {
+func (c *ripemd160hash) Run(input []byte, _ StateDB) ([]byte, error) {
 	ripemd := ripemd160.New()
 	ripemd.Write(input)
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
@@ -312,7 +313,7 @@ type dataCopy struct{}
 func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
-func (c *dataCopy) Run(in []byte) ([]byte, error) {
+func (c *dataCopy) Run(in []byte, _ StateDB) ([]byte, error) {
 	return common.CopyBytes(in), nil
 }
 
@@ -443,7 +444,7 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	return gas.Uint64()
 }
 
-func (c *bigModExp) Run(input []byte) ([]byte, error) {
+func (c *bigModExp) Run(input []byte, _ StateDB) ([]byte, error) {
 	var (
 		baseLen = new(big.Int).SetBytes(getData(input, 0, 32)).Uint64()
 		expLen  = new(big.Int).SetBytes(getData(input, 32, 32)).Uint64()
@@ -523,7 +524,7 @@ func (c *bn256AddIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasIstanbul
 }
 
-func (c *bn256AddIstanbul) Run(input []byte) ([]byte, error) {
+func (c *bn256AddIstanbul) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256Add(input)
 }
 
@@ -536,7 +537,7 @@ func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasByzantium
 }
 
-func (c *bn256AddByzantium) Run(input []byte) ([]byte, error) {
+func (c *bn256AddByzantium) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256Add(input)
 }
 
@@ -561,7 +562,7 @@ func (c *bn256ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasIstanbul
 }
 
-func (c *bn256ScalarMulIstanbul) Run(input []byte) ([]byte, error) {
+func (c *bn256ScalarMulIstanbul) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256ScalarMul(input)
 }
 
@@ -574,7 +575,7 @@ func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasByzantium
 }
 
-func (c *bn256ScalarMulByzantium) Run(input []byte) ([]byte, error) {
+func (c *bn256ScalarMulByzantium) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256ScalarMul(input)
 }
 
@@ -629,7 +630,7 @@ func (c *bn256PairingIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn256PairingPerPointGasIstanbul
 }
 
-func (c *bn256PairingIstanbul) Run(input []byte) ([]byte, error) {
+func (c *bn256PairingIstanbul) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256Pairing(input)
 }
 
@@ -642,7 +643,7 @@ func (c *bn256PairingByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasByzantium + uint64(len(input)/192)*params.Bn256PairingPerPointGasByzantium
 }
 
-func (c *bn256PairingByzantium) Run(input []byte) ([]byte, error) {
+func (c *bn256PairingByzantium) Run(input []byte, _ StateDB) ([]byte, error) {
 	return runBn256Pairing(input)
 }
 
@@ -668,7 +669,7 @@ var (
 	errBlake2FInvalidFinalFlag   = errors.New("invalid final flag")
 )
 
-func (c *blake2F) Run(input []byte) ([]byte, error) {
+func (c *blake2F) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Make sure the input is valid (correct length and final flag)
 	if len(input) != blake2FInputLength {
 		return nil, errBlake2FInvalidInputLength
@@ -722,7 +723,7 @@ func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1AddGas
 }
 
-func (c *bls12381G1Add) Run(input []byte) ([]byte, error) {
+func (c *bls12381G1Add) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G1Add precompile.
 	// > G1 addition call expects `256` bytes as an input that is interpreted as byte concatenation of two G1 points (`128` bytes each).
 	// > Output is an encoding of addition operation result - single G1 point (`128` bytes).
@@ -758,7 +759,7 @@ func (c *bls12381G1Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1MulGas
 }
 
-func (c *bls12381G1Mul) Run(input []byte) ([]byte, error) {
+func (c *bls12381G1Mul) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G1Mul precompile.
 	// > G1 multiplication call expects `160` bytes as an input that is interpreted as byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G1 point (`128` bytes).
@@ -810,7 +811,7 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
 }
 
-func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
+func (c *bls12381G1MultiExp) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G1MultiExp precompile.
 	// G1 multiplication call expects `160*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// Output is an encoding of multiexponentiation operation result - single G1 point (`128` bytes).
@@ -856,7 +857,7 @@ func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2AddGas
 }
 
-func (c *bls12381G2Add) Run(input []byte) ([]byte, error) {
+func (c *bls12381G2Add) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G2Add precompile.
 	// > G2 addition call expects `512` bytes as an input that is interpreted as byte concatenation of two G2 points (`256` bytes each).
 	// > Output is an encoding of addition operation result - single G2 point (`256` bytes).
@@ -893,7 +894,7 @@ func (c *bls12381G2Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2MulGas
 }
 
-func (c *bls12381G2Mul) Run(input []byte) ([]byte, error) {
+func (c *bls12381G2Mul) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G2MUL precompile logic.
 	// > G2 multiplication call expects `288` bytes as an input that is interpreted as byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G2 point (`256` bytes).
@@ -945,7 +946,7 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
 }
 
-func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
+func (c *bls12381G2MultiExp) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 G2MultiExp precompile logic
 	// > G2 multiplication call expects `288*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiexponentiation operation result - single G2 point (`256` bytes).
@@ -991,7 +992,7 @@ func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
-func (c *bls12381Pairing) Run(input []byte) ([]byte, error) {
+func (c *bls12381Pairing) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 Pairing precompile logic.
 	// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
 	// > - `128` bytes of G1 point encoding
@@ -1143,7 +1144,7 @@ func (c *bls12381MapG1) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG1Gas
 }
 
-func (c *bls12381MapG1) Run(input []byte) ([]byte, error) {
+func (c *bls12381MapG1) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 Map_To_G1 precompile.
 	// > Field-to-curve call expects an `64` bytes input that is interpreted as an element of the base field.
 	// > Output of this call is `128` bytes and is G1 point following respective encoding rules.
@@ -1172,7 +1173,7 @@ func (c *bls12381MapG2) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG2Gas
 }
 
-func (c *bls12381MapG2) Run(input []byte) ([]byte, error) {
+func (c *bls12381MapG2) Run(input []byte, _ StateDB) ([]byte, error) {
 	// Implements EIP-2537 Map_FP2_TO_G2 precompile logic.
 	// > Field-to-curve call expects an `128` bytes input that is interpreted as an element of the quadratic extension field.
 	// > Output of this call is `256` bytes and is G2 point following respective encoding rules.
@@ -1218,7 +1219,7 @@ var (
 )
 
 // Run executes the point evaluation precompile.
-func (b *kzgPointEvaluation) Run(input []byte) ([]byte, error) {
+func (b *kzgPointEvaluation) Run(input []byte, _ StateDB) ([]byte, error) {
 	if len(input) != blobVerifyInputLength {
 		return nil, errBlobVerifyInvalidInputLength
 	}
@@ -1259,4 +1260,28 @@ func kZGToVersionedHash(kzg kzg4844.Commitment) common.Hash {
 	h[0] = blobCommitmentVersionKZG
 
 	return h
+}
+
+// statefulPrecompile allows read/write EVM state.
+type statefulPrecompile struct{}
+
+// RequiredGas returns the gas required to execute the pre-compiled contract.
+func (c *statefulPrecompile) RequiredGas(input []byte) uint64 {
+	return params.StatefulPrecompileGas
+}
+
+func (c *statefulPrecompile) Run(input []byte, stateDB StateDB) ([]byte, error) {
+	var address common.Address
+	copy(address[:], input)
+
+	// Read from the state (example: reading a counter)
+	counterKey := common.BytesToHash([]byte("my-counter"))
+	counter := stateDB.GetState(address, counterKey)
+
+	// Increment the counter
+	newCounter := new(big.Int).Add(new(big.Int).SetBytes(counter.Bytes()), big.NewInt(1))
+	stateDB.SetState(address, counterKey, common.BigToHash(newCounter))
+
+	// Return the updated counter as output
+	return newCounter.Bytes(), nil
 }

--- a/core/vm/contracts_fuzz_test.go
+++ b/core/vm/contracts_fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzPrecompiledContracts(f *testing.F) {
 			return
 		}
 		inWant := string(input)
-		RunPrecompiledContract(p, input, gas, nil)
+		RunPrecompiledContract(p, input, gas, nil, nil)
 		if inHave := string(input); inWant != inHave {
 			t.Errorf("Precompiled %v modified input data", a)
 		}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -161,10 +161,7 @@ func TestStatefulPrecompile(t *testing.T) {
 	in := contract.Address().Bytes()
 	gas := p.RequiredGas(in)
 
-	precompile := &statefulPrecompile{}
-
 	{
-		t.Logf("Here")
 		output, _, err := RunPrecompiledContract(p, in, gas, stateDB, nil)
 		if err != nil {
 			t.Fatalf("Stateful precompile run failed: %v", err)
@@ -178,7 +175,7 @@ func TestStatefulPrecompile(t *testing.T) {
 	}
 
 	{
-		output, err := precompile.Run(contract.Address().Bytes(), stateDB)
+		output, _, err := RunPrecompiledContract(p, in, gas, stateDB, nil)
 		if err != nil {
 			t.Fatalf("Stateful precompile run failed: %v", err)
 		}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -208,7 +208,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	evm.Context.Transfer(evm.StateDB, caller.Address(), addr, value)
 
 	if isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.StateDB, evm.Config.Tracer)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -277,7 +277,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.StateDB, evm.Config.Tracer)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -328,7 +328,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.StateDB, evm.Config.Tracer)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -382,7 +382,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	evm.StateDB.AddBalance(addr, new(uint256.Int), tracing.BalanceChangeTouchAccount)
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.StateDB, evm.Config.Tracer)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -159,6 +159,7 @@ const (
 	Bls12381PairingPerPairGas uint64 = 43000 // Per-point pair gas price for BLS12-381 elliptic curve pairing check
 	Bls12381MapG1Gas          uint64 = 5500  // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 75000 // Gas price for BLS12-381 mapping field element to G2 operation
+	StatefulPrecompileGas     uint64 = 1000  // Gas price for statefulPrecompile
 
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529

--- a/semantic-test/README.md
+++ b/semantic-test/README.md
@@ -9,7 +9,7 @@ The `statefulPrecompile` is deployed to the following addresses for the hardfork
 | Cancun   | 0x0b    |
 | Berlin   | 0x0a    |
 
-The smart contract on the `StatefulPrecompile.sol` file is written for the `Prague` hardfork and it uses `0x14` to direct the `statefulPrecompie` contract.
+The smart contract on the `StatefulPrecompile.sol` file is written for the `Prague` hardfork and it uses `0x14` to direct the `statefulPrecompie` contract.<br>
 To test this smart contract on chain, we need to follow these steps.
 - Build the go-ethereum project
 - Run execution node with the new geth binary
@@ -24,7 +24,7 @@ make geth
 This will build the code and generate a `geth` binary on `./build/bin`.
 
 ### Run execution node with the new geth binary
-Before deploy the smart contract, we need to start the custom ethereum network. To make remix communicate with this node, we should allow the remix's url.
+Before deploy the smart contract, we need to start the custom ethereum network. To make remix communicate with this node, we should allow the remix's url.<br>
 We need to initialize the network state by using `genesis.json` file.
 ```bash
 ./build/bin/geth init --datadir ./data genesis.json
@@ -36,10 +36,10 @@ Then, use the following command to run the execution node.
 This will both run the node and open the geth console for the further inspect.
 
 ### Deploy and test the contract by using tools like Remix
-We can use [Remix](https://remix.ethereum.org) to deploy and test the smart contract.
-On the `Deploy & Run Transactions` tab, choose the `Custom - External Http Provider` under the `Environment` dropdown. This will connects Remix to the custom node which we started before.
-Then create a new `sol` file move the content of the `StatefulPrecompile.sol` file in it.
-After that, we can compile and deploy the contract.
+We can use [Remix](https://remix.ethereum.org) to deploy and test the smart contract.<br>
+On the `Deploy & Run Transactions` tab, choose the `Custom - External Http Provider` under the `Environment` dropdown. This will connects Remix to the custom node which we started before.<br>
+Then create a new `sol` file move the content of the `StatefulPrecompile.sol` file in it.<br>
+After that, we can compile and deploy the contract.<br>
 The `callPrecompile` method receives an address of another contract as an input parameter to inject a counter inside it. We should provide a valid contract address when running this method.
 
 ## Additional notes

--- a/semantic-test/README.md
+++ b/semantic-test/README.md
@@ -44,4 +44,14 @@ The `callPrecompile` method receives an address of another contract as an input 
 
 ## Additional notes
 
+### Logging and Debugging
+To log the data from geth, we can use the `log` module by adding `"github.com/ethereum/go-ethereum/log"` to the import statement.<br>
+The `log.Info` method might be useful for logging.
 
+### Change the hardforks
+To test with the lower version of hardforks, we can update the `genesis.json` file. Change the `***Block` field under the `config` field from `0` to large enough number would block the specific hardforks.
+
+### Possible updates
+Here're the checklists for any possible update of the current implementation.
+- Instead of directly update the `Run` method definition of the `PrecompiledContract` interface on `core/vm/contracts.go` file, we can introduce `Polymorphism`.
+- We should avoid using hardcoded `my-counter` key. Maybe we can split the `input`; first 20 bytes for the address and the remaining bytes for key.

--- a/semantic-test/README.md
+++ b/semantic-test/README.md
@@ -8,6 +8,7 @@ The `statefulPrecompile` is deployed to the following addresses for the hardfork
 | Prague   | 0x14    |
 | Cancun   | 0x0b    |
 | Berlin   | 0x0a    |
+
 The smart contract on the `StatefulPrecompile.sol` file is written for the `Prague` hardfork and it uses `0x14` to direct the `statefulPrecompie` contract.
 To test this smart contract on chain, we need to follow these steps.
 - Build the go-ethereum project

--- a/semantic-test/README.md
+++ b/semantic-test/README.md
@@ -1,0 +1,46 @@
+# Test with Smart Contract
+> This guide is dedicated for the technical challenge from SemanticLayer
+
+## Description
+The `statefulPrecompile` is deployed to the following addresses for the hardforks.
+| hardfork | address |
+| :------: | :-----: |
+| Prague   | 0x14    |
+| Cancun   | 0x0b    |
+| Berlin   | 0x0a    |
+The smart contract on the `StatefulPrecompile.sol` file is written for the `Prague` hardfork and it uses `0x14` to direct the `statefulPrecompie` contract.
+To test this smart contract on chain, we need to follow these steps.
+- Build the go-ethereum project
+- Run execution node with the new geth binary
+- Deploy and test the contract by using tools like Remix
+Let's see one by one.
+
+### Build the go-ethereum project
+At the root directory of the project run the following command to build.
+```bash
+make geth
+```
+This will build the code and generate a `geth` binary on `./build/bin`.
+
+### Run execution node with the new geth binary
+Before deploy the smart contract, we need to start the custom ethereum network. To make remix communicate with this node, we should allow the remix's url.
+We need to initialize the network state by using `genesis.json` file.
+```bash
+./build/bin/geth init --datadir ./data genesis.json
+```
+Then, use the following command to run the execution node.
+```bash
+./build/bin/geth --dev --networkid 3151908 --http --http.addr "0.0.0.0" --http.port "8545" --http.api "eth,web3,personal,net,miner,debug" --nodiscover --mine --allow-insecure-unlock --http.corsdomain https://remix.ethereum.org --dev console --vmdebug
+```
+This will both run the node and open the geth console for the further inspect.
+
+### Deploy and test the contract by using tools like Remix
+We can use [Remix](https://remix.ethereum.org) to deploy and test the smart contract.
+On the `Deploy & Run Transactions` tab, choose the `Custom - External Http Provider` under the `Environment` dropdown. This will connects Remix to the custom node which we started before.
+Then create a new `sol` file move the content of the `StatefulPrecompile.sol` file in it.
+After that, we can compile and deploy the contract.
+The `callPrecompile` method receives an address of another contract as an input parameter to inject a counter inside it. We should provide a valid contract address when running this method.
+
+## Additional notes
+
+

--- a/semantic-test/StatefulPrecompile.sol
+++ b/semantic-test/StatefulPrecompile.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "hardhat/console.sol";
+
+contract TestPrecompile {
+    address constant PRECOMPILE_ADDRESS = address(0x14);
+
+    function callPrecompile(bytes memory input) public returns (uint256) {
+        // Call the precompile
+        (bool success, bytes memory output) = PRECOMPILE_ADDRESS.call(input);
+        console.log("Success?", success);
+        console.log("Output length:", output.length);
+        require(success, "Precompile call failed!!!!");
+        console.logBytes32(bytes32(output));
+        require(output.length >= 32, "Data too short");
+
+        // Decode the output (counter value)
+        uint256 counter = abi.decode(output, (uint256));
+        return counter;
+    }
+}

--- a/semantic-test/genesis.json
+++ b/semantic-test/genesis.json
@@ -1,0 +1,49 @@
+
+{
+  "config": {
+    "chainId": 3151908,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 8130134348
+  },
+  "alloc": {
+    "0xfDCe42116f541fc8f7b0776e2B30832bD5621C85": {
+      "balance": "1000000000000000000000000000"
+    },
+    "0xD9211042f35968820A3407ac3d80C725f8F75c14": {
+      "balance": "1000000000000000000000000000"
+    },
+    "0xd55BEB8B973659F754800B2C5defbaef5d17C7c2": {
+      "balance": "1000000000000000000000000000"
+    },
+    "0xafF0CA253b97e54440965855cec0A8a2E2399896": {
+      "balance": "1000000000000000000000000000"
+    },
+    "0xcB1d19FCAB91F11b105f70585359Ef6318Ba7951": {
+      "balance": "1000000000000000000000000000"
+    }
+  },
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "difficulty": "0x01",
+  "extraData": "",
+  "gasLimit": "0x17d7840",
+  "nonce": "0x1234",
+  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp": "1730134328"
+}
+
+


### PR DESCRIPTION
# Add a new Precompiled contracts to go-ethereum

## Description
The `statefulPrecompile` is the contract which read/write the data to the EVM state. It receives an address of another contract as an input and adds a counter to it. The hardcoded keyname `my-counter` is used to store the counter state.

## Deployment
The contract is pre-compiled and available at 0x0a on Berlin hard-fork, 0x0b on Cancun hard-fork, and 0x14 on Prague hard-fork.

## Usage
You can run the contract by calling the spcific address for the hardfork. For example on Prague, you should call the contract from `0x14`.
There is one input parameter which receives the address of the other contract. And it will return an array which holds 32 bytes of data. The returned data represents the counter status.

## Test
To test the contract, you can use the following command.
```bash
go test ./core/vm -run TestStatefulPrecompile -test.v
```
